### PR TITLE
Fixes #39

### DIFF
--- a/src/features/dataset-controls/DatasetSelector.js
+++ b/src/features/dataset-controls/DatasetSelector.js
@@ -9,7 +9,7 @@ function DatasetSelector({ className, selected, datasets, onChange }) {
         onChange={(evt) => onChange(find(eqUrl(evt.target.value), datasets)) }
         value={isNil(selected) ? "" : selected.url}
       >
-        <option value="">&mdash;</option>
+        <option value="">&mdash;None&mdash;</option>
         {datasets.map((dataset) => {
           return (
             <option key={dataset.url} value={dataset.url}>

--- a/src/features/misc-controls/FieldSelect.js
+++ b/src/features/misc-controls/FieldSelect.js
@@ -28,7 +28,7 @@ function FieldSelect({
       onChange={(evt) => onChange(stringToField(fields, evt.target.value))}
       value={isNil(value) ? "" : fieldToString(value)}
     >
-      <option value="">&mdash;</option>
+      <option value="">&mdash;None&mdash;</option>
       {sortBy(getCount(getFieldId, values), fields).map((field) => {
         const key = getFieldId(field);
         return (

--- a/src/features/visualization/d3-viz.js
+++ b/src/features/visualization/d3-viz.js
@@ -181,7 +181,9 @@ function d3Viz(rootNode) {
       coloredField: props.coloredField
     });
 
-    state.legend.update({ nodes: state.nodes })
+    if(state.legend != null){
+      state.legend.update({ nodes: state.nodes })
+    }
   };
 
   const resetZoom = (props, state) => {

--- a/src/features/visualization/d3-viz/setup-legend.js
+++ b/src/features/visualization/d3-viz/setup-legend.js
@@ -21,7 +21,19 @@ import { colorScheme, extendColorScheme } from './color-scheme';
 function setupLegend({ legend, data, hierarchyConfig, coloredField, legendConfig }) {
   if (!coloredField) {
     legend.style("display", "none");
-    return;
+
+    const state = { nodes: [] }
+
+    function update({ nodes }) {
+      state.nodes = nodes;
+      if (!coloredField) {
+        nodes.select('circle').attr('class', null);
+        nodes.classed('viz-coloredNode', false);
+        return;
+      }
+    }
+
+    return { update };
   } else {
     legend.style("display", null);
   }
@@ -55,7 +67,6 @@ function setupLegend({ legend, data, hierarchyConfig, coloredField, legendConfig
 
   function update({ nodes }) {
     state.nodes = nodes;
-
     if (!coloredField) {
       nodes.select('circle').attr('class', null);
       nodes.classed('viz-coloredNode', false);


### PR DESCRIPTION
-added null check in case where an empty legend is returned in order to address the error described by #39
-modified dropdowns to have a default value of -None- to more properly reflect actual behavior of CRViz
-corrected behavior of Color By dropdown so that selecting -None- properly clears colors