### PR TITLE
Improve the UX for setting sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,12 @@ docker run -dp 80:5000 crviz
 
 The static files in the `./build` directory should be ready for deployment.
 
+To serve the application locally, run `npm start`.
+Changes made in your code will be automatically reloaded on http://localhost:5000.
+
 ## Data Input
 
-This tool supports loading datasets from URLs or by uploading local files. When loading dataset from a URL, ensure that [Cross-Origin Resource Sharing](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) is enabled at that URL. 
+This tool supports loading datasets from URLs or by uploading local files. When loading dataset from a URL, ensure that [Cross-Origin Resource Sharing](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) is enabled at that URL.
 
 In both cases, the tool expects the data to be in the format described below.
 For examples, see [`./sample_data`](./sample_data).

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "uuid": "^3.3.2"
   },
   "scripts": {
-    "start": "REACT_APP_VERSION=$npm_package_version react-app-rewired start",
+    "start": "REACT_APP_VERSION=$npm_package_version PORT=5000 react-app-rewired start",
     "build": "REACT_APP_VERSION=$npm_package_version react-app-rewired build",
     "coverage": "nyc report --reporter=text-lcov > coverage/coverage.lcov && codecov",
     "test": "NODE_ENV=test NODE_PATH=./src nyc mocha --opts ./.mocha --exit",

--- a/src/App.js
+++ b/src/App.js
@@ -86,27 +86,27 @@ class App extends Component {
         </label>
         <div className={ style.controls }>
           <Header />
-          <div className={style.accordionHeader}>
-            Data  {!showData && <FontAwesomeIcon onClick={this.toggleShowData} icon={faPlusCircle} />}{showData && <FontAwesomeIcon onClick={this.toggleShowData} icon={faMinusCircle} />}
-          </div> 
+          <div className={style.accordionHeader} onClick={this.toggleShowData}>
+            Data  {!showData && <FontAwesomeIcon icon={faPlusCircle} />}{showData && <FontAwesomeIcon onClick={this.toggleShowData} icon={faMinusCircle} />}
+          </div>
           <div>
             <div className={ classNames({ [style.section]: true, [style.hidden]: !showData }) }>
               <DatasetControls uuid={ this.state.uuid1 } datasets={ datasets }/>
-            </div> 
+            </div>
 
             <div className={ classNames({ [style.section]: true, [style.hidden]: !showData }) }>
               <DatasetControls uuid={ this.state.uuid2 } datasets={ datasets }/>
-            </div> 
-          </div>    
+            </div>
+          </div>
 
           { hasDataset &&
             <div className={ classNames({ [style.section]: true, [style.hidden]: !showData }) }>
               <SearchControls />
             </div>
           }
-          <div className={style.accordionHeader} >
-            Grouping  {!showGrouping && <FontAwesomeIcon onClick={this.toggleShowGrouping} icon={faPlusCircle} />}{showGrouping && <FontAwesomeIcon  onClick={this.toggleShowGrouping} icon={faMinusCircle} />}
-          </div> 
+          <div className={style.accordionHeader} onClick={this.toggleShowGrouping}>
+            Grouping  {!showGrouping && <FontAwesomeIcon icon={faPlusCircle} />}{showGrouping && <FontAwesomeIcon  onClick={this.toggleShowGrouping} icon={faMinusCircle} />}
+          </div>
           { hasDataset &&
             <div className={ classNames({ [style.section]: true, [style.hierarchySection]: true, [style.hidden]: !showGrouping }) }>
               <HierarchySelector />
@@ -119,12 +119,12 @@ class App extends Component {
             </div>
           }
 
-          <div className={style.accordionHeader}>
-            Filtering  {!showFiltering && <FontAwesomeIcon onClick={this.toggleShowFiltering} icon={faPlusCircle} />}{showFiltering && <FontAwesomeIcon onClick={this.toggleShowFiltering} icon={faMinusCircle} />}
-          </div> 
+          <div className={style.accordionHeader} onClick={this.toggleShowFiltering}>
+            Filtering  {!showFiltering && <FontAwesomeIcon icon={faPlusCircle} />}{showFiltering && <FontAwesomeIcon onClick={this.toggleShowFiltering} icon={faMinusCircle} />}
+          </div>
           <div>
 
-          </div> 
+          </div>
         </div>
 
         <div className={ style.canvas }>

--- a/src/App.module.css
+++ b/src/App.module.css
@@ -149,6 +149,11 @@ input[name=hideControls]:checked ~ .canvas {
   align-items: center;
   justify-content: space-between;
   border-bottom: 2px dashed rgba(125, 125, 125, 0.5);
+  cursor: pointer;
+}
+
+.accordionHeader:hover {
+  color: #C62f39;
 }
 
 .hidden {


### PR DESCRIPTION
### Description of proposed changes
Fixes #173:
- Clicking anywhere on the section header will now expand/collapse the section
- Also added some styles (cursor + colour)

Please take a look @cglewis!

Here's a screenshot:

![crvizsectionheader](https://user-images.githubusercontent.com/6725396/47207042-cd829680-d3bc-11e8-97d2-86a529d5df53.gif)

### Checklist
- [x] Lint and unit tests pass locally with my changes
- [ ] ~I have added tests that prove my changes work~ (if applicable)
- [x] I have added or updated necessary documentation (if appropriate)

### Additional comments
- Modified the `npm start` command to include the correct port, aka `PORT=5000`
- Updated readme with the instructions on using `npm start`