### PR TITLE
fix: Closes #193 - sets App Canvas to 100% height of parent element

### DIFF
--- a/src/App.module.css
+++ b/src/App.module.css
@@ -23,6 +23,7 @@
   transform: translateZ(0);
   display: flex;
   flex-direction: column;
+  height: 100%
 }
 
 :global(.darkTheme) .controls {
@@ -49,6 +50,7 @@
   flex: 1 1;
   transition: transform 0.25s;
   transform: translateZ(0);
+  height: 100%
 }
 
 input[name=hideControls] {


### PR DESCRIPTION
### Description of proposed changes
Forces App canvas to maintain a height of 100% of parent element

### Checklist
_Put an `x` in the boxes that apply. _
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my changes work (if applicable)
- [x] I have added or updated necessary documentation (if appropriate)

### Additional comments
None
