### PR TITLE
fix: closes #195 - refresh interval validation handles empty string c…

### DIFF
--- a/src/features/dataset-controls/DatasetControls.js
+++ b/src/features/dataset-controls/DatasetControls.js
@@ -214,6 +214,11 @@ class DatasetControls extends React.Component {
         refreshInterval: numInt,
       });
     }
+    else if(!interval){
+      this.setState({
+        refreshInterval: null,
+      });
+    }
   }
 
   render() {


### PR DESCRIPTION
…orrectly

### Description of proposed changes
the refresh interval input now properly accepts an empty string

### Checklist
_Put an `x` in the boxes that apply. _
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my changes work (if applicable)
- [x] I have added or updated necessary documentation (if appropriate)

### Additional comments
N/A
