### PR TITLE
remove duplicate sudo key and bump node version to 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,13 @@
-sudo: required
+sudo: false
 
 services:
   - docker
 
 language: node_js
 node_js:
-- '8'
+- '11'
 
 dist: trusty
-sudo: false
 
 install:
   - npm install -g codecov


### PR DESCRIPTION
### Description of proposed changes
removes the duplicate `sudo` key favoring the more restrictive `sudo: false`.  

### Checklist
_Put an `x` in the boxes that apply. _
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my changes work (if applicable)
- [x] I have added or updated necessary documentation (if appropriate)

### Additional comments
No
