### PR TITLE
Search across all datasets

### DIFF
--- a/src/domain/dataset.js
+++ b/src/domain/dataset.js
@@ -51,7 +51,6 @@ const getHashFields = (allFields, ignoredFields) => {
 }
 
 const addHashKey = (keys, obj) => {
-  //console.log("addHashKey keys: %o", keys);
   const hashKey = keys.reduce( (h, k) => h + path(k.path, obj) + ":", "");
   obj.CRVIZ["_HASH_KEY"] = hashKey;
 }
@@ -59,6 +58,11 @@ const addHashKey = (keys, obj) => {
 const addHashWithoutIgnored = (fields, obj) => {
   const hash = fields.reduce( (h, f) => h + path(f.path, obj) + "|", "");
   obj.CRVIZ["_HASH_WITHOUT_IGNORED"] = hash;
+}
+
+const addSearchKey = (keys, obj) => {
+  const searchKey = keys.reduce( (h, k) => h + path(k.path, obj) + ":", "");
+  obj.CRVIZ["_SEARCH_KEY"] = searchKey;
 }
 
 const applyHashes = (dataset, configuration) => {
@@ -73,6 +77,7 @@ const applyHashes = (dataset, configuration) => {
 
     addHashKey(Array.isArray(configuration.keyFields) && configuration.keyFields.length > 0 ? configuration.keyFields : configuration.hashFields, i);
     addHashWithoutIgnored(configuration.hashFields, i);
+    addSearchKey(configuration.fields, i);
     keys.push(i.CRVIZ._HASH_KEY);
   });
   const uniqueKeys = Array.from(new Set(keys));

--- a/src/epics/index-dataset-epic.js
+++ b/src/epics/index-dataset-epic.js
@@ -68,7 +68,7 @@ const flattenDataset = (ds, cfg) => {
     return flattened;
 
   for(var key in ds){
-    var item = {'CRVIZ_HASH_KEY':ds[key].CRVIZ["_HASH_KEY"]};
+    var item = {'CRVIZ_SEARCH_KEY':ds[key].CRVIZ["_SEARCH_KEY"]};
     for(var f in cfg.fields){
       var field = cfg.fields[f];
 
@@ -88,7 +88,7 @@ const generateIndex = (payload) => {
                         ? payload.datasets[owner].configuration : configurationFor(dataset);
     var flat = flattenDataset(dataset, configuration);
     const idx = lunr(function () {
-      this.ref('CRVIZ_HASH_KEY');
+      this.ref('CRVIZ_SEARCH_KEY');
       if(configuration && configuration.fields){
         const filteredFields = configuration.fields.filter(f => !f.displayName.includes("/"))
         filteredFields.map((field) => { return this.field(field.displayName.toLowerCase()); })

--- a/src/epics/load-dataset-epic.test.js
+++ b/src/epics/load-dataset-epic.test.js
@@ -72,7 +72,8 @@ describe("loadDatasetEpic", () => {
 				role: { role: "role", confidence: 80 },
 				CRVIZ: {
 		         '_HASH_KEY': "uid1:role:80:",
-		         '_HASH_WITHOUT_IGNORED': "uid1|role|80|"
+		         '_HASH_WITHOUT_IGNORED': "uid1|role|80|",
+		         "_SEARCH_KEY": "uid1:role:80:"
 			    }
 			};
 

--- a/src/epics/search-dataset-epic.js
+++ b/src/epics/search-dataset-epic.js
@@ -49,13 +49,18 @@ const performSearch = (data) => {
     }
   }
 
-  data.dataset.forEach((el) => { el.CRVIZ._isSearchResult = false; });
-  results.forEach((r) => {
-    const res = data.dataset.find(i => i.CRVIZ["_HASH_KEY"] === r.ref);
-    if(res){
-      res.CRVIZ._isSearchResult = true;
-      data.results.push(res);
-    }
+  Object.keys(data.datasets).forEach((key) => {
+    const ds = data.datasets[key].dataset;
+    ds.forEach((el) => { 
+      el.CRVIZ._isSearchResult = false;
+    })
+    results.forEach((r) => {
+      const res = ds.find(i => i.CRVIZ["_SEARCH_KEY"] === r.ref);
+      if(res){
+        res.CRVIZ._isSearchResult = true;
+        data.results.push(res);
+      }
+    });
   });
 };
 

--- a/src/epics/search-dataset-epic.test.js
+++ b/src/epics/search-dataset-epic.test.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import configureStore from "configure-store";
 import { QueryParseError } from 'lunr';
 
-import { setDataset, selectDataset, selectConfiguration } from 'domain/dataset'
+import { setDataset, selectDatasets, selectConfiguration } from 'domain/dataset'
 import { getError } from 'domain/error'
 import { searchDataset } from "./search-dataset-epic"
 import { 
@@ -40,23 +40,24 @@ describe("searchDatasetEpic", () => {
 
 	it("search a dataset", (done) => {
 		const query = 'uid1';
-		const ds = selectDataset(store.getState(), owner);
+		const ds = selectDatasets(store.getState());
 		const indices = getSearchIndices(store.getState());
 
-		const action$ = searchDataset({'dataset': ds, 'queryString': query, 'searchIndices': indices});
+		const action$ = searchDataset({'datasets': ds, 'queryString': query, 'searchIndices': indices});
 		store.dispatch(action$);
 
-		expect(action$.payload.results[0]).to.equal(data[0]);
+		expect(action$.payload.results[0].uid).to.equal(data[0].uid);
+		expect(action$.payload.results[0].CRVIZ._isSearchResult).to.equal(true);
 
 		done();
 	});
 
 	it("search a for a non-existent field", (done) => {
 		const query = 'fake: field';
-		const ds = selectDataset(store.getState(), owner);
+		const ds = selectDatasets(store.getState());
 		const indices = getSearchIndices(store.getState());
 
-		const action$ = searchDataset({'dataset': ds, 'queryString': query, 'searchIndices': indices});
+		const action$ = searchDataset({'datasets': ds, 'queryString': query, 'searchIndices': indices});
 		store.dispatch(action$);
 
 		expect(action$.payload.results.length).to.equal(0);
@@ -68,16 +69,17 @@ describe("searchDatasetEpic", () => {
 	it("clears a search", (done) => {
 		const query = 'uid1';
 		
-		const ds = selectDataset(store.getState(), owner);
+		const ds = selectDatasets(store.getState());
 		const indices = getSearchIndices(store.getState());
 
-		const action$ = searchDataset({'dataset': ds, 'queryString': query, 'searchIndices': indices});
+		const action$ = searchDataset({'datasets': ds, 'queryString': query, 'searchIndices': indices});
 		store.dispatch(action$);
 
-		expect(action$.payload.results[0]).to.equal(data[0]);
+		expect(action$.payload.results[0].uid).to.equal(data[0].uid);
+		expect(action$.payload.results[0].CRVIZ._isSearchResult).to.equal(true);
 
 		const clear = '';
-		const clearAction$ = searchDataset({'dataset': ds, 'queryString': clear, 'searchIndices': indices});
+		const clearAction$ = searchDataset({'datasets': ds, 'queryString': clear, 'searchIndices': indices});
 		store.dispatch(clearAction$);
 
 		expect(clearAction$.payload.results.length).to.equal(0);

--- a/src/features/search/SearchControls.js
+++ b/src/features/search/SearchControls.js
@@ -5,7 +5,7 @@ import { connect } from "react-redux";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faSearch,  faTimesCircle} from "@fortawesome/free-solid-svg-icons";
 
-import { selectDataset, selectConfiguration } from "domain/dataset";
+import { selectDatasets, selectMergedConfiguration } from "domain/dataset";
 
 import { getSearchIndices, getSearchResults } from "epics/index-dataset-epic";
 import { searchDataset } from "epics/search-dataset-epic";
@@ -27,12 +27,13 @@ class Search extends React.Component {
       hasSearch: this.state.queryString !== ''
     });
     var data = {
-      dataset: this.props.dataset,
+      datasets: this.props.datasets,
       configuration: this.props.configuration,
       searchIndices: this.props.searchIndices,
       queryString: this.state.queryString,
       results: this.props.results
     }
+    
     this.props.searchDataset(data);
   }
 
@@ -85,7 +86,7 @@ class Search extends React.Component {
 }
 
 Search.propTypes = {
-  dataset: PropTypes.array,
+  datasets: PropTypes.object,
   configuration: PropTypes.object,
   searchIndex: PropTypes.object,
   queryString: PropTypes.string,
@@ -94,10 +95,9 @@ Search.propTypes = {
 };
 
 const mapStateToProps = (state, ownProps) => {
-  const hash = Object.keys(state.dataset.datasets)[0] || ""
   return {
-    dataset: selectDataset(state, hash),
-    configuration: selectConfiguration(state, hash),
+    datasets: selectDatasets(state),
+    configuration: selectMergedConfiguration(state),
     searchIndices: getSearchIndices(state),
     queryString: state.search.queryString,
     results: getSearchResults(state)

--- a/src/features/search/SearchControls.test.js
+++ b/src/features/search/SearchControls.test.js
@@ -72,7 +72,7 @@ describe('SearchControls', () => {
         const expectedAction = {
             type: 'SEARCH_DATASET',
             payload: {
-                'dataset': dataset,
+                'datasets': initialState.dataset.datasets,
                 'configuration': configuration,
                 'searchIndices': [],
                 'queryString': 'test',
@@ -123,7 +123,7 @@ describe('SearchControls', () => {
         const expectedAction = {
             type: 'SEARCH_DATASET',
             payload: {
-                dataset: dataset,
+                datasets: initialState.dataset.datasets,
                 configuration: configuration,
                 searchIndices: [],
                 queryString: '',


### PR DESCRIPTION
fix(search): modify search to work across all datasets. Additionally,
add a SEARCH_KEY property to each object to deal with the fact that HASH_KEY
can change. The search indicies need a key to use to identify an object,
the neccesity of changing the HASH_KEY property to handle user definitions
of "sameness" over time  causes the linking of search results to fail.
Rather than re-indexing all datasets every time a user resets the keying properties
an immutable search key was added to use as a reference.
fixes #364

### Checklist
_Put an `x` in the boxes that apply. _
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my changes work (if applicable)
- [x] I have added or updated necessary documentation (if appropriate)

### Additional comments
Is there anything else you want us to know?
Isn't that wall of text enough?