### PR TITLE
fix(): persistence of show/hide tooltip status

### DIFF
--- a/src/features/tooltip/Tooltip.js
+++ b/src/features/tooltip/Tooltip.js
@@ -15,6 +15,10 @@ class TooltipControls extends React.Component {
   constructor(props){
     super(props)
     this.state = this.initialState;
+    this.state = {
+      ...this,
+      show:true
+    }
   }
 
   get initialState(){
@@ -24,7 +28,7 @@ class TooltipControls extends React.Component {
       width:"300px",
       position: [200,200],
       currentLabel:"",
-      show: true,
+      //show: true,
       note: {
         id:'',
         note:{

--- a/src/features/tooltip/Tooltip.js
+++ b/src/features/tooltip/Tooltip.js
@@ -28,7 +28,6 @@ class TooltipControls extends React.Component {
       width:"300px",
       position: [200,200],
       currentLabel:"",
-      //show: true,
       note: {
         id:'',
         note:{
@@ -190,15 +189,15 @@ class TooltipControls extends React.Component {
               <h3>{this.props.data.fieldValue} </h3>
             </div>
           }
-          <p className={appStyle.accordionHeader} onClick={this.toggleShowNote}>
-            Notes {!showNote && <FontAwesomeIcon icon={faAngleDoubleDown} />}{showNote && <FontAwesomeIcon  onClick={this.toggleShowNote} icon={faAngleDoubleUp} />}
-          </p>
+          {!this.props.data.fieldValue  &&
+            <p className={appStyle.accordionHeader} onClick={this.toggleShowNote}>
+              Notes {!showNote && <FontAwesomeIcon icon={faAngleDoubleDown} />}{showNote && <FontAwesomeIcon  onClick={this.toggleShowNote} icon={faAngleDoubleUp} />}
+            </p>
+          }
           
           {showNote === true &&
           <div>
-            <div>
-              <b><h1><input style={inputStyle} type="text" value={this.state.note.note.title} onChange={this.handleChangeTitle} placeholder="Title"/></h1></b>
-            </div>
+            <b><h1><input style={inputStyle} type="text" value={this.state.note.note.title} onChange={this.handleChangeTitle} placeholder="Title"/></h1></b>
             <p><textarea style={inputStyle} type="text" value={this.state.note.note.content} onChange={this.handleChangeContent} placeholder="Take a note..."/></p>
             <div style={{textAlign:"center"}}>
               <label className="button circular">

--- a/src/features/tooltip/Tooltip.js
+++ b/src/features/tooltip/Tooltip.js
@@ -163,11 +163,12 @@ class TooltipControls extends React.Component {
     return (
       <>{this.props.data &&
         <div style={ this.state.show ? style.show : style.hide }>
+          <p>
+            {!this.state.show && <div className={tooltipStyle.hidden}><FontAwesomeIcon onClick={this.handleShowHide} icon={faAngleDoubleLeft} /> </div>}{this.state.show && <div className={tooltipStyle.shown}><FontAwesomeIcon onClick={this.handleShowHide} icon={faAngleDoubleRight} /></div>}
+          </p>
           {this.props.data && !this.props.data.fieldValue  &&
             <>
-              <p>
-                {!this.state.show && <div className={tooltipStyle.hidden}><FontAwesomeIcon onClick={this.handleShowHide} icon={faAngleDoubleLeft} /> </div>}{this.state.show && <div className={tooltipStyle.shown}><FontAwesomeIcon onClick={this.handleShowHide} icon={faAngleDoubleRight} /></div>}
-              </p>
+              
               <div>
                 <p><b>UID: </b>{this.props.data.uid} </p>
                 <p><b>MAC: </b>{this.props.data.mac} </p>


### PR DESCRIPTION
tooltip will now show when user presses a node then will have the show/hide status persist for different clicks of each node

### Description of proposed changes
#434 Addresses unintended interaction
### Checklist
_Put an `x` in the boxes that apply. _
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my changes work (if applicable)
- [x] I have added or updated necessary documentation (if appropriate)

### Additional comments
Is there anything else you want us to know?
