### PR TITLE
Remove dataset entry for "Poseidon Network"

### DIFF
--- a/src/features/dataset-controls/DatasetControls.js
+++ b/src/features/dataset-controls/DatasetControls.js
@@ -54,19 +54,6 @@ const authTypes = [
   {'name': 'Token', 'scheme':'Bearer' },
 ];
 
-var host = window.location.host;
-var hostname = window.location.hostname;
-var port = '80';
-const radix = 10;
-if (host.indexOf(':') > -1) {
-  port = String(parseInt(host.split(":")[1], radix)-1);
-}
-
-var POSEIDON_DATASET = {
-  name: "Poseidon Network",
-  url: "http://"+hostname+":5000/v1/network"
-};
-
 Modal.setAppElement('#root');
 
 class DatasetControls extends React.Component {
@@ -95,9 +82,6 @@ class DatasetControls extends React.Component {
     };
 
     this.datasets = [...this.props.datasets, CUSTOM_DATASET, UPLOAD_DATASET]
-    if (port !== '80') {
-      this.datasets.push(POSEIDON_DATASET)
-    }
     if(initialDS){
       this.datasets.push(initialDS)
     }


### PR DESCRIPTION
### Description of proposed changes
removes dataset entry for "Poseidon Network"
this functionality should now be accessed by passing a name and url
as querystring paramters.
Closes #516

### Checklist
_Put an `x` in the boxes that apply. _
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my changes work (if applicable)
- [x] I have added or updated necessary documentation (if appropriate)

### Additional comments
None
